### PR TITLE
Exit gracefully the script if env variable is not set

### DIFF
--- a/scripts/papertrail.coffee
+++ b/scripts/papertrail.coffee
@@ -25,6 +25,9 @@
 #
 
 module.exports = (robot) ->
+  if !process.env.HUBOT_PAPERTRAIL_API_TOKEN
+    robot.logger.error "Missing HUBOT_PAPERTRAIL_API_TOKEN in environment: please set and try again"
+    return
   baseUrl = "https://papertrailapp.com/api/v1/"
 
   http_request = (path) ->


### PR DESCRIPTION
Avoiding not initialisation of Hubot if the environment variable is not set in the system.